### PR TITLE
Adding Python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Excel or database systems will easily be able to import the data.
 
 I created a short introduction for this tool on YouTube: https://youtu.be/aYK0gILDA6w
 
-This works with Python v2, but it should also work with Python v3.  If you find it does not work
-with Python v3 please post an issue.
+This works with Python v2 and Python v3. If you find it does not workwith Python v3 
+please post an issue.
 
 ## Help Screen:
 

--- a/hostintel.py
+++ b/hostintel.py
@@ -9,7 +9,7 @@ import libs.network
 # Required for complex command line argument parsing.
 import argparse
 # Required for configuration files
-import ConfigParser
+from configparser import ConfigParser
 # Required for CSV
 import csv
 # Required for STDOUT
@@ -65,7 +65,7 @@ parser.add_argument('-r','--carriagereturn', action='store_true', help='Use carr
 args = parser.parse_args()
 
 # Parse Configuration File
-ConfigFile = ConfigParser.ConfigParser()
+ConfigFile = ConfigParser()
 ConfigFile.read(args.ConfigurationFile)
 
 # Setup the headers list

--- a/hostintel.py
+++ b/hostintel.py
@@ -209,7 +209,11 @@ for host in hosts:
             output.writerow(Headers)
 
         # Print out the data
-        output.writerow([unicode(field).encode('utf-8') for field in row])
+        try:
+            output.writerow([unicode(field).encode('utf-8') for field in row])
+        except:
+            output.writerow([str(field) for field in row])
+
         
         # This turns off headers for remaining rows
         PrintHeaders = False


### PR DESCRIPTION
Hello, there! 

As I mentioned in #9, I have made a few small updates that make hostintel work in both Python 2 and Python 3. I only tested Python 2.7. The current guidance on 2to3 compatibility efforts is to drop 2.6 and older. I also updated the README slightly to reflect this change. Please let me know if this all looks OK!

Thanks!

--
Brie